### PR TITLE
Removing adminHelp and cleaning up re-initialize commands

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -10,23 +10,19 @@ class AdministrationCommands:
     def __init__(self, bot, configMgr: ConfigManager):
         self.bot = bot
         self.configManager = configMgr
-        self.bot.add_command(self.addRole)
-        self.bot.add_command(self.remRole)
-        self.bot.add_command(self.addRoleMgr)
-        self.bot.add_command(self.remRoleMgr)
-        self.bot.add_command(self.listRoleMgrs)
-        self.bot.add_command(self.adminHelp)
-        self.bot.add_command(self.updateConfig)
-    
-    @commands.command()
-    @commands.guild_only()
-    async def adminHelp(self, ctx):
-        output = 'Available Commands:\nAdd a user to a Role: !addRole <role> <user>\nRemove a user from a Role: !remRole <role> <user>'
-        if ctx.author.guild_permissions.administrator:
-            output += '\nAdd a Role Manager: !addRoleMgr <role> <user>\nRemove a Role Manager: !remRoleMgr <role> <user>\nList Role Managers: !listRoleMgrs <role>'
-        if self.bot.is_owner(ctx.author):
-            output += "\nShut it all down: !shutdown"
-        await ctx.send(output)
+        if self.addRole not in self.bot.commands :
+            self.bot.add_command(self.addRole)
+        if self.remRole not in self.bot.commands :
+            self.bot.add_command(self.remRole)
+        if self.addRoleMgr not in self.bot.commands :
+            self.bot.add_command(self.addRoleMgr)
+        if self.remRoleMgr not in self.bot.commands :
+            self.bot.add_command(self.remRoleMgr)
+        if self.listRoleMgrs not in self.bot.commands :
+            self.bot.add_command(self.listRoleMgrs)
+        if self.updateConfig not in self.bot.commands :
+            self.bot.add_command(self.updateConfig)
+
 
     @commands.command()
     @commands.guild_only()


### PR DESCRIPTION
We can't blindly call add_command(), because it will attempt to add existing commands to the bot on a reconnect.  Quick existence check first.